### PR TITLE
Methods for mapping Wikipedia ID (Page ID) to Wikidata ID and back (tests included)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,32 @@ or from the command line via
 Mapping id to title can lead to more than one result, as some pages in Wikipedia are
 redirects, all linking to the same Wikidata item.
 
+Map Wikipedia id to Wikidata id
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+    from wikimapper import WikiMapper
+
+    mapper = WikiMapper("index_enwiki-latest.db")
+    wikidata_id = mapper.wikipedia_id_to_id(3342)
+    print(wikidata_id)  # Q183
+
+
+Map Wikidata id to Wikipedia id
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+    from wikimapper import WikiMapper
+
+    mapper = WikiMapper("index_enwiki-latest.db")
+    wikipedia_ids = mapper.id_to_wikipedia_ids("Q183")
+    print(wikipedia_ids)  # [3342, 10590, 11833, 11840, ...]
+
+Mapping Wikidata id to Wikipedia id can lead to more than one result, as some pages in Wikipedia are
+redirects, all linking to the same Wikidata item.
+
 Create your own index
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import List
 
 BAVARIAN_PARAMS = [
     pytest.param("Stoaboog", "Q168327"),
@@ -48,3 +49,48 @@ def test_id_to_titles(bavarian_wiki_mapper, wikidata_id: str, expected: str):
     titles = mapper.id_to_titles(wikidata_id)
 
     assert set(titles) == set(expected)
+
+
+@pytest.mark.parametrize(
+    "wikipedia_id, expected",
+    [
+        (24520, "Q168327"),   # Stoaboog
+        (8535, "Q243242"),    # Wechslkrod
+        (32218, None),        # Wechslkrod, but namespace 1, so cannot be in the database
+        (32176, "Q2567666"),  # Wickiana
+        (32252, "Q123034"),   # Ulrich_Zwingli
+        (32311, "Q1821239"),  # Jingstes_Gricht
+        (2143, "Q251022"),    # Sånkt_Johann_im_Pongau
+        (2217, "Q25343"),     # Quadrátkilometa
+        (4209, "Q20616808"),  # D'_boarische_Woocha
+        (1997, "Q160525"),    # Brezn
+        (5740, None),         # Brezn, but namespace 1, so cannot be in the database
+        (24100, "Q160525"),   # Brezel
+        (28193, "Q160525"),   # Brezen
+        (105208, "Q102904"),  # Vulkanologie
+        (105288, "Q102904"),  # Vuikanologie
+    ]
+)
+def test_wikipedia_id_to_id(bavarian_wiki_mapper, wikipedia_id: int, expected: str):
+    mapper = bavarian_wiki_mapper
+
+    wikidata_id = mapper.wikipedia_id_to_id(wikipedia_id)
+
+    assert wikidata_id == expected
+
+
+@pytest.mark.parametrize(
+    "wikidata_id, expected",
+    [
+        ("Q1027119", [105563, 105564, 105565]),   # Gallesium, Gallese, Gallesium_(Titularbistum)
+        ("Q102904", [105208, 105288]),            # Vulkanologie, Vuikanologie
+        ("Q160525", [1997, 2778, 24100, 28193]),  # Brezn, Breze, Brezel, Brezen
+        ("12345678909876543210", []),
+    ]
+)
+def test_id_to_wikipedia_id(bavarian_wiki_mapper, wikidata_id: str, expected: List[int]):
+    mapper = bavarian_wiki_mapper
+
+    wikipedia_ids = mapper.id_to_wikipedia_id(wikidata_id)
+
+    assert set(wikipedia_ids) == set(expected)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -88,9 +88,9 @@ def test_wikipedia_id_to_id(bavarian_wiki_mapper, wikipedia_id: int, expected: s
         ("12345678909876543210", []),
     ]
 )
-def test_id_to_wikipedia_id(bavarian_wiki_mapper, wikidata_id: str, expected: List[int]):
+def test_id_to_wikipedia_ids(bavarian_wiki_mapper, wikidata_id: str, expected: List[int]):
     mapper = bavarian_wiki_mapper
 
-    wikipedia_ids = mapper.id_to_wikipedia_id(wikidata_id)
+    wikipedia_ids = mapper.id_to_wikipedia_ids(wikidata_id)
 
     assert set(wikipedia_ids) == set(expected)

--- a/wikimapper/mapper.py
+++ b/wikimapper/mapper.py
@@ -70,3 +70,47 @@ class WikiMapper:
         results = c.fetchall()
 
         return [e[0] for e in results]
+
+    def wikipedia_id_to_id(self, wikipedia_id: int) -> Optional[str]:
+        """Given a Wikipedia ID (in other words Page ID), returns the corresponding Wikidata ID.
+
+        Wikipedia ID is another way to access Wikipedia Article and is widely used in Wikipedia dumps.
+        For example, for the ID `18630637` we can use the link - `http://en.wikipedia.org/?curid=18630637`.
+
+        Args:
+            wikipedia_id (int): The Wikipedia ID to map, e.g. `18630637`
+
+        Returns:
+            Optional[str]: If a mapping found for `wikipedia_id`, then return
+                           it, else return `None`.
+        """
+
+        c = self.conn.execute(
+            "SELECT wikidata_id FROM mapping WHERE wikipedia_id=?", (wikipedia_id,)
+        )
+        result = c.fetchone()
+
+        if result is not None and result[0] is not None:
+            return result[0]
+        else:
+            return None
+
+    def id_to_wikipedia_id(self, wikidata_id: str) -> List[str]:
+        """Given a Wikidata ID, returns the corresponding list of Wikipedia IDs (or Page IDs).
+
+        Due to redirects, there can be multiple Wikipedia IDs for the same Wikidata item.
+
+        Args:
+            wikidata_id (str): The Wikidata ID to map, e.g. `18630637`
+
+        Returns:
+            List[str]: A list of Wikipedia IDs linked to the given Wikidata ID.
+        """
+
+        # no need for `DISTINCT` as `wikipedia_id` is a PRIMARY KEY, thus we have no duplicates there
+        c = self.conn.execute(
+            "SELECT wikipedia_id FROM mapping WHERE wikidata_id=?", (wikidata_id,)
+        )
+        results = c.fetchall()
+
+        return [e[0] for e in results]

--- a/wikimapper/mapper.py
+++ b/wikimapper/mapper.py
@@ -95,7 +95,7 @@ class WikiMapper:
         else:
             return None
 
-    def id_to_wikipedia_id(self, wikidata_id: str) -> List[int]:
+    def id_to_wikipedia_ids(self, wikidata_id: str) -> List[int]:
         """Given a Wikidata ID, returns the corresponding list of Wikipedia IDs (or Page IDs).
 
         Due to redirects, there can be multiple Wikipedia IDs for the same Wikidata item.

--- a/wikimapper/mapper.py
+++ b/wikimapper/mapper.py
@@ -95,16 +95,16 @@ class WikiMapper:
         else:
             return None
 
-    def id_to_wikipedia_id(self, wikidata_id: str) -> List[str]:
+    def id_to_wikipedia_id(self, wikidata_id: str) -> List[int]:
         """Given a Wikidata ID, returns the corresponding list of Wikipedia IDs (or Page IDs).
 
         Due to redirects, there can be multiple Wikipedia IDs for the same Wikidata item.
 
         Args:
-            wikidata_id (str): The Wikidata ID to map, e.g. `18630637`
+            wikidata_id (str): The Wikidata ID to map, e.g. `Q7553`
 
         Returns:
-            List[str]: A list of Wikipedia IDs linked to the given Wikidata ID.
+            List[int]: A list of Wikipedia IDs linked to the given Wikidata ID.
         """
 
         # no need for `DISTINCT` as `wikipedia_id` is a PRIMARY KEY, thus we have no duplicates there


### PR DESCRIPTION
Wikipedia ID is used in multiple SQL dumps, and since I use Wikidata IDs as keys in my data, this mapping can be really useful